### PR TITLE
WIP: Release 0.0.3

### DIFF
--- a/recipe/PR_11.patch
+++ b/recipe/PR_11.patch
@@ -1,0 +1,33 @@
+From a2fe17722f8aa1f5c2d8353203f4d598f915a31f Mon Sep 17 00:00:00 2001
+From: John Kirkham <kirkhamj@janelia.hhmi.org>
+Date: Thu, 9 Mar 2017 02:37:45 -0500
+Subject: [PATCH] Use NumPy 32-bit int in `tinfo` doctest.
+
+Appears that on Windows `int` means 32-bit int even when a 64-bit build
+of Python was made. So instead of relying on `int` generally, which will
+vary between 64-bit or 32-bit for Unix or Windows respectively, specify
+the number of bits with a NumPy type. Also as there is a chance of
+representation subtleties between Unix and Windows with a 64-bit int
+(e.g. `L` postfix) chose a type that is least likely to run into these
+issues in the doctest. In particular, switch to a 32-bit int from NumPy.
+This both specifies a specific type of integer and picks one where its
+max and min values will fall within what a 32-bit int can represent.
+---
+ npctypes/types.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git npctypes/types.py npctypes/types.py
+index 3eb55cc..7618b35 100644
+--- npctypes/types.py
++++ npctypes/types.py
+@@ -29,8 +29,8 @@ def tinfo(a_type):
+             >>> tinfo(complex)
+             finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
+ 
+-            >>> tinfo(int)
+-            iinfo(min=-9223372036854775808, max=9223372036854775807, dtype=int64)
++            >>> tinfo(numpy.int32)
++            iinfo(min=-2147483648, max=2147483647, dtype=int32)
+     """
+ 
+     a_type = numpy.dtype(a_type).type

--- a/recipe/PR_12.patch
+++ b/recipe/PR_12.patch
@@ -1,0 +1,31 @@
+From 414856473075f7460ac7a0906b3f0c55989ce5c4 Mon Sep 17 00:00:00 2001
+From: John Kirkham <kirkhamj@janelia.hhmi.org>
+Date: Thu, 9 Mar 2017 10:26:09 -0500
+Subject: [PATCH] Fix doctest on Windows by forcing shape of `int`s
+
+Unfortunately Windows and Unix handle 64-bit integers differently. This
+is because on Windows `int` represents 32-bit integers; whereas, on Unix
+`int` represents 64-bit integers. As NumPy wants to use large enough
+integers to have 64-bit precision, it uses Python's `int` on Unix and
+Python's `long` on Windows. This causes a doctest that relies on shape
+in `get_ndpointer_type` to fail on Windows. Particularly this fails on
+Windows Python 2.7 64-bit. To fix this, we forcibly convert the shape to
+`int` values regardless of what that means. This should stabilize the
+representation of these values across platforms.
+---
+ npctypes/types.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git npctypes/types.py npctypes/types.py
+index 7618b35..6ff1e02 100644
+--- npctypes/types.py
++++ npctypes/types.py
+@@ -93,7 +93,7 @@ def get_ndpointer_type(a):
+             dtype('float64')
+             >>> a_ptr._ndim_
+             2
+-            >>> a_ptr._shape_
++            >>> tuple(int(s) for s in a_ptr._shape_)
+             (3, 4)
+             >>> a_ptr._flags_
+             1285

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,12 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # Patch a doctest to fix a failure on Windows.
+    #
+    # https://github.com/jakirkham/npctypes/pull/11
+    #
+    - PR_11.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "npctypes" %}
-{% set version = "0.0.2" %}
-{% set sha256 = "79e27d0358d9768f64a30ba20f4d5e8391fb7e9eaefe112955e8e066abce3005" %}
+{% set version = "0.0.3" %}
+{% set sha256 = "c479357f73817142468d0e9f0c9f17ba58a6e16b6960f53f0bbd6a98038e513e" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,14 @@ requirements:
     - numpy
 
 test:
+  source_files:
+    - tests
+
   imports:
     - npctypes
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/jakirkham/npctypes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,13 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
-    # Patch a doctest to fix a failure on Windows.
+    # Patch doctests to fix failures on Windows.
     #
     # https://github.com/jakirkham/npctypes/pull/11
+    # https://github.com/jakirkham/npctypes/pull/12
     #
     - PR_11.patch
+    - PR_12.patch
 
 build:
   number: 0


### PR DESCRIPTION
```markdown
### v0.0.3

* Upgrade versioneer to 0.17. #7
* Extend license copyright into 2017. #8
* Recut with cookiecutter. #9
* Update copyright years in docs. #10
```