### PR TITLE
Release 0.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "npctypes" %}
-{% set version = "0.0.2" %}
-{% set sha256 = "79e27d0358d9768f64a30ba20f4d5e8391fb7e9eaefe112955e8e066abce3005" %}
+{% set version = "0.0.4" %}
+{% set sha256 = "4832bfce8dbc35298c8bea7d1533c9f500691a51719fb10bb2ffce59123d5e50" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,14 @@ requirements:
     - numpy
 
 test:
+  source_files:
+    - tests
+
   imports:
     - npctypes
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/jakirkham/npctypes


### PR DESCRIPTION
```markdown
### v0.0.4

* Use NumPy 32-bit int in `tinfo` doctest. #11
* Fix doctest on Windows by forcing shape of `int`s. #12
```

```markdown
### v0.0.3

* Upgrade versioneer to 0.17. #7
* Extend license copyright into 2017. #8
* Recut with cookiecutter. #9
* Update copyright years in docs. #10
```

Note: Replaces PR ( https://github.com/conda-forge/npctypes-feedstock/pull/9 ).